### PR TITLE
Add keyid to iv

### DIFF
--- a/draft-omara-sframe.md
+++ b/draft-omara-sframe.md
@@ -342,10 +342,10 @@ Key = HKDF(K, 'SFrameAuthenticationKey', 32)
 ~~~~~
 
 
-The IV is 128 bits long and calculated from the CTR field of the Frame header:
+The IV is 128 bits long and calculated from the KeyId and the CTR field of the Frame header:
 
 ~~~~~
-IV = (CTR) XOR Salt key
+IV = (KeyId  CTR) XOR Salt key
 ~~~~~
 
 

--- a/draft-omara-sframe.md
+++ b/draft-omara-sframe.md
@@ -345,7 +345,7 @@ Key = HKDF(K, 'SFrameAuthenticationKey', 32)
 The IV is 128 bits long and calculated from the KeyId and the CTR field of the Frame header:
 
 ~~~~~
-IV = (KeyId  CTR) XOR Salt key
+IV = (KeyId || CTR) XOR Salt key
 ~~~~~
 
 


### PR DESCRIPTION
Do we need to specify the padding of both keyid and CTR somehow?


```
IV = (Pad(KeyId,8) || Pad(CTR,8)) XOR Salt key
```