### PR TITLE
Incorporate the KID in key derivation

### DIFF
--- a/draft-ietf-sframe-enc.md
+++ b/draft-ietf-sframe-enc.md
@@ -380,10 +380,14 @@ associated to a KID.  Given a `base_key` value, the key and salt are derived
 using HKDF {{!RFC5869}} as follows:
 
 ~~~~~
-sframe_secret = HKDF-Extract(base_key, 'SFrame10')
+sframe_secret = HKDF-Extract(base_key, 'SFrame 1.0 ' + KID)
 sframe_key = HKDF-Expand(sframe_secret, 'key', AEAD.Nk)
 sframe_salt = HKDF-Expand(sframe_secret, 'salt', AEAD.Nn)
 ~~~~~
+
+In the derivation of `sframe_secret`, the `+` operator represents concatenation
+of octet strings and the KID value is encoded as an 8-byte big-endian integer
+(not the compressed form used in the SFrame header).
 
 The hash function used for HKDF is determined by the ciphersuite in use.
 

--- a/draft-ietf-sframe-enc.md
+++ b/draft-ietf-sframe-enc.md
@@ -641,7 +641,7 @@ group.
 To generate keys and nonces for SFrame, we use the MLS exporter function to
 generate a `base_key` value for each MLS epoch.  Each member of the group is
 assigned a unique KID value, so that each member has a unique `sframe_key` and
-`sframe_salt` that it uses to encrypt with. 
+`sframe_salt` that it uses to encrypt with.
 
 ~~~~~
 base_key = MLS-Exporter("SFrame 1.0", "", AEAD.Nk)

--- a/draft-ietf-sframe-enc.md
+++ b/draft-ietf-sframe-enc.md
@@ -638,20 +638,18 @@ step in the lifetime of the group is know as an "epoch", and each member of the
 group is assigned an "index" that is constant for the time they are in the
 group.
 
-In SFrame, we derive per-sender `base_key` values from the group secret for an
-epoch, and use the KID field to signal the epoch and sender index.  First, we
-use the MLS exporter to compute a shared SFrame secret for the epoch.
+To generate keys and nonces for SFrame, we use the MLS exporter function to
+generate a `base_key` value for each MLS epoch.  Each member of the group is
+assigned a unique KID value, so that each member has a unique `sframe_key` and
+`sframe_salt` that it uses to encrypt with. 
 
 ~~~~~
-sframe_epoch_secret = MLS-Exporter("SFrame 10 MLS", "", AEAD.Nk)
-
-sender_base_key[index] = HKDF-Expand(sframe_epoch_secret,
-                           encode_big_endian(index, 4), AEAD.Nk)
+base_key = MLS-Exporter("SFrame 1.0", "", AEAD.Nk)
 ~~~~~
 
-For compactness, do not send the whole epoch number.  Instead, we send only its
+For compactness, we do not send the whole epoch number.  Instead, we send only its
 low-order E bits.  Note that E effectively defines a re-ordering window, since
-no more than 2^E epoch can be active at a given time.  Receivers MUST be
+no more than 2^E epochs can be active at a given time.  Receivers MUST be
 prepared for the epoch counter to roll over, removing an old epoch when a new
 epoch with the same E lower bits is introduced.  (Sender indices cannot be
 similarly compressed.)


### PR DESCRIPTION
This PR adds the KID in the derivation of the key and salt to be used with SFrame encryption/decryption under that KID.  This change improves the nonce-reuse-resilience of  SFrame, since (with high probability) a nonce will only be reused if the same `base_key` and `KID` are used, as opposed to just the same `base_key`.

The approach here is similar to the one proposed in #25, and to the key/nonce derivation in SRTP.  In SRTP, the same encryption key is used across several contexts, but the nonce space is segmented by SSRC.  The algorithms for [CTR](https://www.rfc-editor.org/rfc/rfc3711#section-4.1.1) and [GCM](https://www.rfc-editor.org/rfc/rfc7714#section-8.1) are slightly different, but both XOR the SSRC and packet index with the constant salt.  Here the KID is hashed into the salt and the key, playing a similar distinguishing role to the SSRC.