### PR TITLE
Clarify that header confidentiality relies on lower layers

### DIFF
--- a/draft-ietf-sframe-enc.md
+++ b/draft-ietf-sframe-enc.md
@@ -835,6 +835,16 @@ arrived and was decrypted.
 
 # Security Considerations
 
+## No Header Confidentiality
+
+SFrame provides integrity protection to the SFrame Header (the key ID and
+counter values), but does not provide confidentiality protection.  Parties that
+can observe the SFrame header may learn, for example, which parties are sending
+SFrame payloads (from KID values) and at what rates (from CTR values).  In cases
+where SFrame is used for end-to-end security on top of hop-by-hop protections
+(e.g., running over SRTP as described in {{sframe-over-rtp}}), the hop-by-hop security
+mechanisms will typically protect the SFrame header against network attackers.
+
 ## No Per-Sender Authentication
 
 SFrame does not provide per-sender authentication of media data.  Any sender in

--- a/draft-ietf-sframe-enc.md
+++ b/draft-ietf-sframe-enc.md
@@ -843,7 +843,7 @@ can observe the SFrame header may learn, for example, which parties are sending
 SFrame payloads (from KID values) and at what rates (from CTR values).  In cases
 where SFrame is used for end-to-end security on top of hop-by-hop protections
 (e.g., running over SRTP as described in {{sframe-over-rtp}}), the hop-by-hop security
-mechanisms will typically protect the SFrame header against network attackers.
+mechanisms provide confidentiality protection of the SFrame header between hops.
 
 ## No Per-Sender Authentication
 


### PR DESCRIPTION
Fixes #142 