### PR TITLE
Remove use of 'IV'

### DIFF
--- a/draft-ietf-sframe-enc.md
+++ b/draft-ietf-sframe-enc.md
@@ -590,8 +590,8 @@ def compute_tag(auth_key, nonce, aad, ct):
 
 def AEAD.Encrypt(key, nonce, aad, pt):
   enc_key, auth_key = derive_subkeys(key)
-  iv = nonce + 0x00000000 # append four zero bytes
-  ct = AES-CTR.Encrypt(enc_key, iv, pt)
+  initial_counter = nonce + 0x00000000 # append four zero bytes
+  ct = AES-CTR.Encrypt(enc_key, initial_counter, pt)
   tag = compute_tag(auth_key, nonce, aad, ct)
   return ct + tag
 
@@ -603,8 +603,8 @@ def AEAD.Decrypt(key, nonce, aad, ct):
   if !constant_time_equal(tag, candidate_tag):
     raise Exception("Authentication Failure")
 
-  iv = nonce + 0x00000000 # append four zero bytes
-  return AES-CTR.Decrypt(enc_key, iv, inner_ct)
+  initial_counter = nonce + 0x00000000 # append four zero bytes
+  return AES-CTR.Decrypt(enc_key, initial_counter, inner_ct)
 ~~~~~
 
 # Key Management

--- a/draft-ietf-sframe-enc.md
+++ b/draft-ietf-sframe-enc.md
@@ -103,9 +103,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 BCP 14 {{!RFC2119}} {{!RFC8174}} when, and only when, they appear in all
 capitals, as shown here.
 
-IV:
-: Initialization Vector
-
 MAC:
 : Message Authentication Code
 
@@ -231,7 +228,7 @@ the parties in the conference.  Keys for SFrame might be distributed over an
 existing E2E-secure channel (see {{sender-keys}}), or derived from an E2E-secure
 shared secret (see {{mls}}).  The key management system MUST ensure that each
 key used for encrypting media is used by exactly one media sender, in order to
-avoid reuse of IVs.
+avoid reuse of nonces.
 
 ## SFrame Ciphertext
 
@@ -275,7 +272,7 @@ The SFrame header specifies two values from which encryption parameters are
 derived:
 
 * A Key ID (KID) that determines which encryption key should be used
-* A counter (CTR) that is used to construct the IV for the encryption
+* A counter (CTR) that is used to construct the nonce for the encryption
 
 Applications MUST ensure that each (KID, CTR) combination is used for exactly
 one encryption operation. A typical approach to achieving this guarantee is


### PR DESCRIPTION
Fixes #155 

As noted in #155, the document uses both "IV" and "nonce".  In addition to my and @chris-wood's preferences for "nonce", "IV" was used only a handful of times.  So this PR eliminates those few uses.