### PR TITLE
Add a requirement to discard invalid ciphertexts

### DIFF
--- a/draft-ietf-sframe-enc.md
+++ b/draft-ietf-sframe-enc.md
@@ -524,7 +524,9 @@ def decrypt(metadata, sframe_ciphertext):
 If a ciphertext fails to decrypt because there is no key available for the KID
 in the SFrame header, the client MAY buffer the ciphertext and retry decryption
 once a key with that KID is received.  If a ciphertext fails to decrypt for any
-other reason, the client MUST discard the ciphertext.
+other reason, the client MUST discard the ciphertext. Invalid ciphertexts SHOULD be
+discarded in a way that is indistinguishable (to an external observer) from having 
+processed a valid ciphertext.
 
 ## Cipher Suites
 

--- a/draft-ietf-sframe-enc.md
+++ b/draft-ietf-sframe-enc.md
@@ -861,7 +861,7 @@ one SFrame encrypted frame with an incrementing frame counter.
 
 ## Video Key Frames
 
-Forward Security and Post-Compromise Security requires that the E2EE keys (base keys) 
+Forward Security and Post-Compromise Security require that the E2EE keys (base keys)
 are updated any time a participant joins or leaves the call.
 
 The key exchange happens asynchronously and on a different path than the SFU signaling

--- a/draft-ietf-sframe-enc.md
+++ b/draft-ietf-sframe-enc.md
@@ -493,8 +493,6 @@ header ----+------------------>| AAD
 ~~~~~
 {: title="Encryption flow" }
 
-[[ TODO: Text about obeying AEAD limits ]]
-
 ### Decryption
 
 Before decrypting, a client needs to assemble a full SFrame ciphertext. When

--- a/draft-ietf-sframe-enc.md
+++ b/draft-ietf-sframe-enc.md
@@ -898,7 +898,7 @@ packets per second.  If an attacker saturated such a link with guesses against a
 roughly once every 2^12 seconds, or about once an hour.
 
 In a typical SFrame usage in a real-time media application, there are a few
-factors that mitigate this risk:
+approaches to mitigating this risk:
 
 * Receivers only accept SFrame ciphertexts over HBH-secure channels (e.g., SRTP
   security associations or QUIC connections).  So only an entity that is part of
@@ -922,15 +922,15 @@ factors that mitigate this risk:
   value.  Since the CTR value is covered by SFrame authentication, an attacker
   has to do a fresh search for a valid tag for every forged ciphertext, even if
   the encrypted content is unchanged.  In other words, when the above brute
-  force attacke succeeds, it only allows the attacker to send a single SFrame
+  force attack succeeds, it only allows the attacker to send a single SFrame
   ciphertext; the ciphertext cannot be reused because either it will have the
   same CTR value and be discarded as a replay, or else it will have a different
   CTR value its tag will no longer be valid.
 
-Nonetheless, applications that make use of short tags need to put these
-mitigations in place.  In many cases, it is simpler to use full-size tags and
-tolerate slightly higher bandwidth usage rather than add the additional defenses
-necessary to safely use short tags.
+Nonetheless, without these mitigations, an application that makes use of short
+tags will be at heightened risk of forgery attacks.  In many cases, it is
+simpler to use full-size tags and tolerate slightly higher bandwidth usage
+rather than add the additional defenses necessary to safely use short tags.
 
 # IANA Considerations
 

--- a/draft-ietf-sframe-enc.md
+++ b/draft-ietf-sframe-enc.md
@@ -525,7 +525,7 @@ If a ciphertext fails to decrypt because there is no key available for the KID
 in the SFrame header, the client MAY buffer the ciphertext and retry decryption
 once a key with that KID is received.  If a ciphertext fails to decrypt for any
 other reason, the client MUST discard the ciphertext. Invalid ciphertexts SHOULD be
-discarded in a way that is indistinguishable (to an external observer) from having 
+discarded in a way that is indistinguishable (to an external observer) from having
 processed a valid ciphertext.
 
 ## Cipher Suites
@@ -911,7 +911,7 @@ factors that mitigate this risk:
   succeed even less often than the high-rate attack described above.  On the
   other hand, the application may use an elevated packet arrival rate as a
   signal of a brute-force attack.  This latter approach is common in other
-  settings, e.g., brute-forcing of passwords.
+  settings, e.g., mitigating brute-force attacks on passwords.
 
 * Media applications typically do not provide feedback to media senders as to
   which media packets failed to decrypt.  When media quality feedback
@@ -919,22 +919,20 @@ factors that mitigate this risk:
   losses, but only at an aggregate level.
 
 * Anti-replay mechanisms (see {{replay}}) prevent the attacker from re-using
-  legitimate ciphertexts.  Since the attacker is limited in their ability to
-  synthesize new legitimate (ciphertexts, tag) pairs (e.g., limited to flipping
-  bits in AES-CTR or AES-GCM ciphertexts), they can basically only cause the
-  media decoder to decode random data.
+  valid ciphertexts (either observed or guessed by the attacker).  A receiver
+  applying anti-replay controls will only accept one valid plaintext per CTR
+  value.  Since the CTR value is covered by SFrame authentication, an attacker
+  has to do a fresh search for a valid tag for every forged ciphertext, even if
+  the encrypted content is unchanged.  In other words, when the above brute
+  force attacke succeeds, it only allows the attacker to send a single SFrame
+  ciphertext; the ciphertext cannot be reused because either it will have the
+  same CTR value and be discarded as a replay, or else it will have a different
+  CTR value its tag will no longer be valid.
 
-In summary, with proper mitigations, short tags allow an attacker to send random
-data to a media stream at a very low rate, using an attack that is
-straightforward to recognize and neutralize.  At best, the attacker can trigger
-a denial-of-service condition, which they likely could have done anyway simply
-by sending meaningless packets, without regard for whether they pass the
-authentication check.
-
-Nonetheless, applications that make use of short tags need to put in place the
-mitigations discussed above.  In many cases, it is simpler to use full-size tags
-and tolerate slightly higher bandwidth usage rather than add the additional
-defenses necessary to safely use short tags.
+Nonetheless, applications that make use of short tags need to put these
+mitigations in place.  In many cases, it is simpler to use full-size tags and
+tolerate slightly higher bandwidth usage rather than add the additional defenses
+necessary to safely use short tags.
 
 # IANA Considerations
 


### PR DESCRIPTION
This PR adds text requiring ciphertexts that do not decrypt to be discarded.  It also adds some discussion of the impact of this requirement on the safety of short tags.  (Thanks to @bren2010 for helping refine this analysis.)

@chris-wood - in #154 you mention addressing AEAD limits.  Could you suggest some text for that?  I was not able to interpret the CFRG draft.  Also, it seems like we would need some analogous analysis for the AES-CTR-based AEAD modes described here.  Do you have thoughts on that?