### PR TITLE
Better encrypt/decrypt diagrams

### DIFF
--- a/draft-ietf-sframe-enc.md
+++ b/draft-ietf-sframe-enc.md
@@ -515,6 +515,7 @@ Header |   | KID |  |                     |
     |                                     |
     |                                AEAD.Encrypt
     |                                     |
+    |               SFrame Ciphertext     |
     |               +---------------+     |
     +-------------->| SFrame Header |     |
                     +---------------+     |
@@ -525,7 +526,7 @@ Header |   | KID |  |                     |
                     |               |
                     +---------------+
 ~~~~~
-{: title="Encryption flow" }
+{: title="Encrypting an SFrame Ciphertext" }
 
 ### Decryption
 
@@ -562,6 +563,7 @@ discarded in a way that is indistinguishable (to an external observer) from havi
 processed a valid ciphertext.
 
 ~~~~~ aasvg
+                    SFrame Ciphertext
                     +---------------+
     +---------------| SFrame Header |
     |               +---------------+
@@ -599,7 +601,7 @@ processed a valid ciphertext.
                                   |               |
                                   +---------------+
 ~~~~~
-{: title="Decryption flow" }
+{: title="Decrypting an SFrame Ciphertext" }
 
 ## Cipher Suites
 


### PR DESCRIPTION
Replaces #176 

* As in #176, makes clear that the header encoding the KID and CTR is what goes into AAD and the SFrame ciphertext
* Removes the "S" field
* Adds the corresponding decryption flow diagram