### PR TITLE
Add base_key to uniqueness requirement

### DIFF
--- a/draft-ietf-sframe-enc.md
+++ b/draft-ietf-sframe-enc.md
@@ -1064,12 +1064,13 @@ order for SFrame to operate securely.
 
 ## Header Value Uniqueness
 
-Applications MUST ensure that each (KID, CTR) combination is used for at most
-one SFrame encryption operation. Typically this is done by assigning each sender
-a KID or set of KIDs, then having each sender use the CTR field as a monotonic
-counter, incrementing for each plaintext that is encrypted. In addition to its
-simplicity, this scheme minimizes overhead by keeping CTR values as small as
-possible.
+Applications MUST ensure that each (`base_key`, KID, CTR) combination is used
+for at most one SFrame encryption operation. This ensures that the (key, nonce)
+pairs used by the underlying AEAD algorithm are never reused. Typically this is
+done by assigning each sender a KID or set of KIDs, then having each sender use
+the CTR field as a monotonic counter, incrementing for each plaintext that is
+encrypted. In addition to its simplicity, this scheme minimizes overhead by
+keeping CTR values as small as possible.
 
 ## Key Management Framework
 


### PR DESCRIPTION
@martinthomson noted in #173 that the KID value be reused, e.g., when the epoch rolls over in the MLS case.  That's OK as long as the `base_key` is different on either side of the roll-over.  This PR updates the uniqueness constraints to capture that option.